### PR TITLE
Avoid clobbering unaffected pins on classic ATTinys

### DIFF
--- a/TinyTFTGraphicsLibrary.ino
+++ b/TinyTFTGraphicsLibrary.ino
@@ -31,7 +31,7 @@ int const cs = 3;
 #define PORT_TOGGLE(x)  PINB = (x)
 #define PORT_LOW(x)     PORTB = PORTB & ~((x));
 #define PORT_HIGH(x)    PORTB = PORTB | ((x))
-#define PORT_OUTPUT(x)  DDRB = (x)
+#define PORT_OUTPUT(x)  DDRB = DDRB | (x)
 
 #endif
 


### PR DESCRIPTION
Fix PORT_OUTPUT macro so it doesn't clobber unaffected pins.

Even though the library utilizes _most_ of the available pins on an ATTinyx5, it does not use them all. The macro should not be changing the data direction (DDRB) on pins not controlled by the library. In my case, it disabled a serial port I was writing to while trying to use the library. With this patch, the serial port functions again.

I am not able to test if this issue affects the 0-, 1-, and 2- variants, but I think they are ok.

Thanks for a fantastic library!